### PR TITLE
feat: Add web page for VLESS configuration display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Ini memungkinkan Anda untuk merutekan lalu lintas internet Anda melalui jaringan
 - **Transport WebSocket (WS)**: Membungkus lalu lintas VLESS dalam koneksi WebSocket, membuatnya tampak seperti lalu lintas web HTTPS biasa dan sulit untuk dideteksi atau diblokir.
 - **Dukungan Penuh Jaringan (Full Proxy)**: Setelah terhubung, semua lalu lintas TCP Anda akan dirutekan melalui worker.
 - **Berjalan di Jaringan CDN Cloudflare**: Mendapatkan manfaat dari kecepatan, latensi rendah, dan stabilitas jaringan global Cloudflare.
-- **Rute Fallback (Penyamaran)**: Permintaan yang bukan koneksi VLESS (misalnya, kunjungan dari browser) akan dialihkan ke situs web lain, sehingga worker Anda tidak terlihat mencurigakan.
+- **Halaman Konfigurasi Web**: Mengunjungi alamat utama worker akan menampilkan halaman web yang berisi semua detail konfigurasi dan link `vless://` yang bisa disalin dengan satu klik.
+- **Rute Fallback (Penyamaran)**: Permintaan ke path lain (selain path VLESS dan path utama) akan dialihkan ke situs web lain, sehingga worker Anda tidak terlihat mencurigakan.
 - **Konfigurasi Mudah**: Cukup edit file `wrangler.toml` untuk mengatur UUID, path rahasia, dan host fallback Anda.
 - **Keamanan TLS**: Semua koneksi secara otomatis diamankan dengan TLS (HTTPS) oleh Cloudflare.
 - **Dukungan Domain Kustom**: Dapat dengan mudah dihubungkan ke domain atau subdomain pribadi Anda.


### PR DESCRIPTION
This commit introduces a new feature that serves an HTML page at the root URL of the worker. This page dynamically displays the VLESS connection parameters, including the address, UUID, path, and other relevant details.

Key changes:
- A new function `handleConfigRequest` is added to `src/index.ts` to generate the HTML page.
- The page includes a "Copy Link" button that uses JavaScript to copy the full `vless://` configuration URI to the user's clipboard, simplifying client setup.
- The main routing logic in `fetch` handler is updated to route requests for the root path (`/`) to this new function.
- The `README.md` file is updated to document this new feature.