### PR TITLE
refactor: Obfuscate web page content for better stealth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ini memungkinkan Anda untuk merutekan lalu lintas internet Anda melalui jaringan
 - **Transport WebSocket (WS)**: Membungkus lalu lintas VLESS dalam koneksi WebSocket, membuatnya tampak seperti lalu lintas web HTTPS biasa dan sulit untuk dideteksi atau diblokir.
 - **Dukungan Penuh Jaringan (Full Proxy)**: Setelah terhubung, semua lalu lintas TCP Anda akan dirutekan melalui worker.
 - **Berjalan di Jaringan CDN Cloudflare**: Mendapatkan manfaat dari kecepatan, latensi rendah, dan stabilitas jaringan global Cloudflare.
-- **Halaman Konfigurasi Web**: Mengunjungi alamat utama worker akan menampilkan halaman web yang berisi semua detail konfigurasi dan link `vless://` yang bisa disalin dengan satu klik.
+- **Halaman Detail Koneksi**: Mengunjungi alamat utama worker akan menampilkan halaman web yang berisi detail koneksi dan URI konfigurasi yang dapat disalin.
 - **Rute Fallback (Penyamaran)**: Permintaan ke path lain (selain path VLESS dan path utama) akan dialihkan ke situs web lain, sehingga worker Anda tidak terlihat mencurigakan.
 - **Konfigurasi Mudah**: Cukup edit file `wrangler.toml` untuk mengatur UUID, path rahasia, dan host fallback Anda.
 - **Keamanan TLS**: Semua koneksi secara otomatis diamankan dengan TLS (HTTPS) oleh Cloudflare.

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ function compareArrays(a: Uint8Array, b: Uint8Array): boolean {
  */
 function handleConfigRequest(url: URL, env: Env): Response {
 	const address = url.hostname;
+	// The vlessLink remains the same, as it's just a text string.
 	const vlessLink = `vless://${env.UUID}@${address}:443?path=${encodeURIComponent(env.VLESS_PATH)}&security=tls&encryption=none&host=${address}&type=ws#${encodeURIComponent(address)}`;
 
 	const html = `
@@ -273,7 +274,7 @@ function handleConfigRequest(url: URL, env: Env): Response {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>VLESS Configuration</title>
+    <title>Connection Details</title>
     <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 40px; background-color: #f4f4f7; color: #333; }
         .container { max-width: 700px; margin: 0 auto; background-color: #fff; padding: 20px 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
@@ -290,24 +291,24 @@ function handleConfigRequest(url: URL, env: Env): Response {
 </head>
 <body>
     <div class="container">
-        <h1>VLESS Configuration</h1>
-        <p>Use the following details to configure your V2Ray/Xray client.</p>
+        <h1>Connection Details</h1>
+        <p>Use the following details for your client application.</p>
 
         <table>
             <tr><th>Parameter</th><th>Value</th></tr>
             <tr><td>Address</td><td>${address}</td></tr>
             <tr><td>Port</td><td>443</td></tr>
-            <tr><td>UUID</td><td>${env.UUID}</td></tr>
+            <tr><td>ID / UUID</td><td>${env.UUID}</td></tr>
             <tr><td>Network</td><td>ws (WebSocket)</td></tr>
             <tr><td>Security</td><td>tls</td></tr>
             <tr><td>Path</td><td>${env.VLESS_PATH}</td></tr>
             <tr><td>Host / SNI</td><td>${address}</td></tr>
         </table>
 
-        <h2>Configuration Link</h2>
-        <p>Click the button below to copy the VLESS configuration link:</p>
-        <div class="config-link" id="vlessLink">${vlessLink}</div>
-        <button class="copy-button" onclick="copyConfig()">Copy Link</button>
+        <h2>Configuration URI</h2>
+        <p>Click the button below to copy the configuration URI:</p>
+        <div class="config-link" id="configLink">${vlessLink}</div>
+        <button class="copy-button" onclick="copyConfig()">Copy URI</button>
     </div>
 
     <div class="footer">
@@ -316,9 +317,9 @@ function handleConfigRequest(url: URL, env: Env): Response {
 
     <script>
         function copyConfig() {
-            const link = document.getElementById('vlessLink').innerText;
+            const link = document.getElementById('configLink').innerText;
             navigator.clipboard.writeText(link).then(() => {
-                alert('VLESS link copied to clipboard!');
+                alert('Configuration URI copied to clipboard!');
             }, (err) => {
                 alert('Failed to copy: ', err);
             });


### PR DESCRIPTION
This commit refactors the HTML page served at the root URL to remove explicit mentions of "VLESS". This is a security-through-obscurity measure to make the worker less identifiable.

Key changes:
- All user-facing text on the configuration page, such as "VLESS Configuration" and "VLESS link", has been replaced with more generic terms like "Connection Details" and "Configuration URI".
- The `README.md` has been updated to reflect these changes.

The functionality remains the same, but the presentation is now more neutral.