### PR TITLE
fix: Enable TCP sockets and document dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Ini memungkinkan Anda untuk merutekan lalu lintas internet Anda melalui jaringan
 1.  Akun [Cloudflare](https://dash.cloudflare.com/sign-up).
 2.  [Node.js](https://nodejs.org/en/) dan `npm` terinstal di komputer Anda.
 
+**Catatan Penting Mengenai Konektivitas:**
+Worker ini menggunakan fitur `connect()` (TCP Sockets) untuk meneruskan lalu lintas. Fitur ini secara resmi merupakan bagian dari paket **Cloudflare Workers Paid**. Meskipun terkadang berfungsi pada paket gratis, fungsionalitas penuh tidak dijamin. Jika Anda mengalami error koneksi setelah deploy berhasil, ini kemungkinan besar adalah penyebabnya.
+
 ### Langkah 1: Dapatkan File Proyek
 
 Unduh atau salin semua file dari proyek ini ke direktori di komputer Anda.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,8 @@
 name = "vless-worker" # TODO: Change this to your worker's name
 main = "src/index.ts"
 compatibility_date = "2024-04-05"
+# This flag is required to enable outbound TCP sockets via `connect()`.
+compatibility_flags = ["workers_sockets"]
 
 [vars]
 # Your custom UUID. You can generate one from https://www.uuidgenerator.net/


### PR DESCRIPTION
This commit fixes a critical runtime error (`Invalid HTTP method string: CONNECT`) by enabling the required feature for outbound TCP connections.

Key changes:
- Adds the `workers_sockets` compatibility flag to `wrangler.toml`. This is necessary to use the `connect()` API for creating TCP sockets.
- Updates `README.md` to include an important note explaining that this feature is officially part of the Cloudflare Workers Paid plan and that connectivity issues might persist on the Free plan due to this limitation.

This change should resolve the connection failures for users on an appropriate Cloudflare plan.